### PR TITLE
float->int bugfix in "lowcommon"

### DIFF
--- a/pyslic/preprocess/preprocess.py
+++ b/pyslic/preprocess/preprocess.py
@@ -169,7 +169,8 @@ def bgsub(img,options = {}):
             T = 0
         else:
             hist = fullhistogram(img)
-            T = np.argmax(hist[:M])
+            # type has changed; need to cast as int
+            T = np.argmax(hist[:int(M)])
         if T > 0:
             img -= np.minimum(img,T)
         return img


### PR DESCRIPTION
Bugfix: 'lowcommon' path histogram refuses to run if M is a float, which with new versions of numpy (1.9), it will be.  Older versions of numpy will silently ignore the int(-) cast.
